### PR TITLE
NAS-111800 / 13.0 / Perform destination retention before replication in order to free up disk space / quotas (by themylogin)

### DIFF
--- a/integration-tests/replication/test_data_progress.py
+++ b/integration-tests/replication/test_data_progress.py
@@ -46,7 +46,7 @@ def test_replication_data_progress():
     with patch("zettarepl.replication.run.DatasetSizeObserver.INTERVAL", 5):
         definition = Definition.from_data(definition)
         zettarepl = create_zettarepl(definition)
-        zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+        zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
         wait_replication_tasks_to_complete(zettarepl)
 
     calls = [call for call in zettarepl.observer.call_args_list

--- a/integration-tests/replication/test_parallel_replication.py
+++ b/integration-tests/replication/test_parallel_replication.py
@@ -88,7 +88,7 @@ def test_parallel_replication():
 
     local_shell = LocalShell()
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
 
     start = time.monotonic()
     wait_replication_tasks_to_complete(zettarepl)
@@ -108,7 +108,7 @@ def test_parallel_replication():
     subprocess.check_call("zfs create data/dst/b", shell=True)
 
     zettarepl._replication_tasks_can_run_in_parallel = Mock(return_value=False)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
 
     start = time.monotonic()
     wait_replication_tasks_to_complete(zettarepl)
@@ -220,7 +220,7 @@ def test_parallel_replication_3(max_parallel_replications):
     definition = Definition.from_data(definition)
 
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
 
     start = time.monotonic()
     wait_replication_tasks_to_complete(zettarepl)

--- a/integration-tests/replication/test_pre_retention.py
+++ b/integration-tests/replication/test_pre_retention.py
@@ -1,0 +1,78 @@
+# -*- coding=utf-8 -*-
+from datetime import datetime
+import subprocess
+import textwrap
+
+import pytest
+import yaml
+
+from zettarepl.utils.test import create_dataset, run_replication_test
+
+
+@pytest.mark.parametrize("direction", ["push", "pull"])
+@pytest.mark.parametrize("recursive", [True, False])
+@pytest.mark.parametrize("retention_policy", ["source", "custom"])
+def test_pre_retention(direction, recursive, retention_policy):
+    subprocess.call("zfs destroy -r data/src", shell=True)
+    subprocess.call("zfs destroy -r data/dst", shell=True)
+
+    create_dataset("data/src")
+    create_dataset("data/src/a")
+    create_dataset("data/src/b")
+    subprocess.check_call("zfs set quota=200M data/src", shell=True)
+    subprocess.check_call("dd if=/dev/urandom of=/mnt/data/src/a/blob bs=1K count=90000", shell=True)
+    subprocess.check_call("zfs snapshot -r data/src@2018-10-01_01-00", shell=True)
+    subprocess.check_call("dd if=/dev/urandom of=/mnt/data/src/a/blob bs=1K count=90000", shell=True)
+    subprocess.check_call("zfs snapshot -r data/src@2018-10-01_02-00", shell=True)
+    subprocess.check_call("zfs send -R data/src@2018-10-01_01-00 | zfs recv -s -F data/dst", shell=True)
+    subprocess.check_call(
+        "zfs send -R -i data/src@2018-10-01_01-00 data/src@2018-10-01_02-00 | zfs recv -s -F data/dst", shell=True,
+    )
+    subprocess.check_call("zfs destroy -r data/src@2018-10-01_01-00", shell=True)
+    subprocess.check_call("dd if=/dev/urandom of=/mnt/data/src/a/blob bs=1K count=90000", shell=True)
+    subprocess.check_call("zfs snapshot -r data/src@2018-10-01_03-00", shell=True)
+
+    definition = yaml.safe_load(textwrap.dedent(f"""\
+        timezone: "UTC"
+
+        periodic-snapshot-tasks:
+          src:
+            dataset: data/src
+            recursive: true
+            lifetime: PT1H
+            naming-schema: "%Y-%m-%d_%H-%M"
+            schedule:
+              minute: "0"
+
+        replication-tasks:
+          src:
+            transport:
+              type: local
+            target-dataset: data/dst
+            properties: true
+            auto: false
+            retention-policy: source
+            retries: 1
+    """))
+
+    if direction == "push":
+        definition["replication-tasks"]["src"]["direction"] = "push"
+        definition["replication-tasks"]["src"]["periodic-snapshot-tasks"] = ["src"]
+    else:
+        definition["replication-tasks"]["src"]["direction"] = "pull"
+        definition["replication-tasks"]["src"]["naming-schema"] = "%Y-%m-%d_%H-%M"
+
+    if recursive:
+        definition["replication-tasks"]["src"]["source-dataset"] = "data/src"
+        definition["replication-tasks"]["src"]["recursive"] = True
+    else:
+        definition["replication-tasks"]["src"]["source-dataset"] = ["data/src/a", "data/src/b"]
+        definition["replication-tasks"]["src"]["recursive"] = False
+
+    if retention_policy == "source":
+        definition["replication-tasks"]["src"]["retention-policy"] = "source"
+    else:
+        definition["replication-tasks"]["src"]["retention-policy"] = "custom"
+        definition["replication-tasks"]["src"]["lifetime"] = "PT1H"
+
+    run_replication_test(definition, now=datetime(2018, 10, 2))

--- a/integration-tests/replication/test_preserves_deleted_datasets.py
+++ b/integration-tests/replication/test_preserves_deleted_datasets.py
@@ -51,7 +51,7 @@ def test_push_replication():
 
     definition = Definition.from_data(definition)
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     assert sum(1 for m in zettarepl.observer.call_args_list if isinstance(m[0][0], ReplicationTaskSuccess)) == 1
@@ -59,7 +59,7 @@ def test_push_replication():
     subprocess.check_call("zfs destroy -r data/src/child", shell=True)
     subprocess.check_call("zfs snapshot data/src@2018-10-01_02-00", shell=True)
 
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     assert sum(1 for m in zettarepl.observer.call_args_list if isinstance(m[0][0], ReplicationTaskSuccess)) == 2

--- a/integration-tests/replication/test_progress.py
+++ b/integration-tests/replication/test_progress.py
@@ -56,7 +56,7 @@ def test_replication_progress(transport):
 
     definition = Definition.from_data(definition)
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     calls = [call for call in zettarepl.observer.call_args_list
@@ -150,7 +150,7 @@ def test_replication_progress_resume():
 
     definition = Definition.from_data(definition)
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     calls = [call for call in zettarepl.observer.call_args_list
@@ -214,7 +214,7 @@ def test_replication_progress_pre_calculate():
 
     definition = Definition.from_data(definition)
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     calls = [call for call in zettarepl.observer.call_args_list

--- a/integration-tests/replication/test_push_replication.py
+++ b/integration-tests/replication/test_push_replication.py
@@ -83,7 +83,7 @@ def test_push_replication(dst_parent_is_readonly, dst_exists, transport, replica
     observer = Mock()
     zettarepl.set_observer(observer)
     zettarepl.set_tasks(definition.tasks)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     if dst_exists and properties and encrypted and not dst_parent_encrypted:
@@ -106,7 +106,7 @@ def test_push_replication(dst_parent_is_readonly, dst_exists, transport, replica
 
     subprocess.check_call("zfs snapshot -r data/src@2018-10-01_03-00", shell=True)
 
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     error = observer.call_args_list[-1][0][0]

--- a/integration-tests/replication/test_replication_retry.py
+++ b/integration-tests/replication/test_replication_retry.py
@@ -61,7 +61,7 @@ def test_replication_retry(caplog, direction):
 
     caplog.set_level(logging.INFO)
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
 
     time.sleep(2)
     if direction == "push":

--- a/integration-tests/replication/test_snapshot_gone.py
+++ b/integration-tests/replication/test_snapshot_gone.py
@@ -72,7 +72,7 @@ def test_snapshot_gone(transport):
         return resume_replications(*args, **kwargs)
 
     with patch("zettarepl.replication.run.resume_replications", resume_replications_mock):
-        zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+        zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
         wait_replication_tasks_to_complete(zettarepl)
 
     error = observer.call_args_list[-1][0][0]

--- a/integration-tests/transport/test_ssh_authentication_error.py
+++ b/integration-tests/transport/test_ssh_authentication_error.py
@@ -78,7 +78,7 @@ def test_replication_retry(caplog):
 
     caplog.set_level(logging.INFO)
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(None, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     assert any(

--- a/zettarepl/replication/pre_retention.py
+++ b/zettarepl/replication/pre_retention.py
@@ -1,0 +1,65 @@
+# -*- coding=utf-8 -*-
+from datetime import datetime
+import logging
+
+from zettarepl.dataset.relationship import is_child
+from zettarepl.retention.calculate import calculate_snapshots_to_remove
+from zettarepl.snapshot.destroy import destroy_snapshots
+from zettarepl.snapshot.snapshot import Snapshot
+from zettarepl.transport.timeout import ShellTimeoutContext
+
+from .snapshots_to_send import get_parsed_incremental_base
+from .task.dataset import get_source_dataset
+from .task.snapshot_owner import ExecutedReplicationTaskSnapshotOwner
+from .task.task import ReplicationTask
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["pre_retention"]
+
+
+class RetentionBeforePushReplicationSnapshotOwner(ExecutedReplicationTaskSnapshotOwner):
+    def __init__(self, target_dataset: str, *args, **kwargs):
+        self.target_dataset = target_dataset
+        super().__init__(*args, **kwargs)
+
+        for dst_dataset, snapshots in self.delete_snapshots.items():
+            incremental_base = get_parsed_incremental_base(
+                self.parsed_src_snapshots_names.get(get_source_dataset(self.replication_task, dst_dataset), []),
+                self.parsed_dst_snapshots_names[dst_dataset]
+            )
+            if incremental_base:
+                try:
+                    snapshots.remove(incremental_base)
+                except ValueError:
+                    pass
+
+    def owns_dataset(self, dataset: str):
+        # FIXME: Replication tasks that have multiple source datasets are executed as independent parts.
+        # Retention has to be executed as independent parts too. Part 2 retention will not be executed until part 1
+        # replication is completed. That might lead to disk space / quota overflow which could have been prevented
+        # if all retentions were executed first.
+        return is_child(dataset, self.target_dataset) and super().owns_dataset(dataset)
+
+
+def pre_retention(now: datetime, replication_task: ReplicationTask, source_snapshots: {str: [str]},
+                  target_snapshots: {str: [str]}, target_dataset: str, target_shell):
+    owners = [
+        RetentionBeforePushReplicationSnapshotOwner(target_dataset, now, replication_task, source_snapshots,
+                                                    target_snapshots)
+    ]
+    remote_snapshots = sum(
+        [
+            [
+                Snapshot(dataset, snapshot)
+                for snapshot in snapshots
+            ]
+            for dataset, snapshots in target_snapshots.items()
+        ],
+        []
+    )
+
+    snapshots_to_destroy = calculate_snapshots_to_remove(owners, remote_snapshots)
+    logger.info("Pre-retention destroying snapshots: %r", snapshots_to_destroy)
+    with ShellTimeoutContext(3600):
+        destroy_snapshots(target_shell, snapshots_to_destroy)

--- a/zettarepl/replication/snapshots_to_send.py
+++ b/zettarepl/replication/snapshots_to_send.py
@@ -1,0 +1,18 @@
+# -*- coding=utf-8 -*-
+import logging
+
+from zettarepl.snapshot.name import parsed_snapshot_sort_key
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["get_parsed_incremental_base"]
+
+
+def get_parsed_incremental_base(parsed_src_snapshots, parsed_dst_snapshots):
+    try:
+        return sorted(
+            set(parsed_src_snapshots) & set(parsed_dst_snapshots),
+            key=parsed_snapshot_sort_key,
+        )[-1]
+    except IndexError:
+        return None

--- a/zettarepl/replication/task/snapshot_owner.py
+++ b/zettarepl/replication/task/snapshot_owner.py
@@ -100,11 +100,11 @@ class ExecutedReplicationTaskSnapshotOwner(BaseReplicationTaskSnapshotOwner):
         self.src_snapshots = src_snapshots
         self.dst_snapshots = dst_snapshots
 
-        parsed_src_snapshots_names = {
+        self.parsed_src_snapshots_names = {
             dataset: parse_snapshots_names_with_multiple_schemas(snapshots, self.get_naming_schemas())
             for dataset, snapshots in self.src_snapshots.items()
         }
-        parsed_dst_snapshots_names = {
+        self.parsed_dst_snapshots_names = {
             dataset: parse_snapshots_names_with_multiple_schemas(snapshots, self.get_naming_schemas())
             for dataset, snapshots in self.dst_snapshots.items()
         }
@@ -112,8 +112,8 @@ class ExecutedReplicationTaskSnapshotOwner(BaseReplicationTaskSnapshotOwner):
         self.delete_snapshots = {
             dst_dataset: self.replication_task.retention_policy.calculate_delete_snapshots(
                 now,
-                parsed_src_snapshots_names.get(get_source_dataset(self.replication_task, dst_dataset), []),
-                parsed_dst_snapshots_names.get(dst_dataset, []),
+                self.parsed_src_snapshots_names.get(get_source_dataset(self.replication_task, dst_dataset), []),
+                self.parsed_dst_snapshots_names.get(dst_dataset, []),
             )
             for dst_dataset in self.dst_snapshots.keys()
             if replication_task_replicates_target_dataset(replication_task, dst_dataset)

--- a/zettarepl/utils/test.py
+++ b/zettarepl/utils/test.py
@@ -60,10 +60,10 @@ def run_periodic_snapshot_test(definition, now, success=True):
             assert not isinstance(call, PeriodicSnapshotTaskError), success
 
 
-def run_replication_test(definition, success=True):
+def run_replication_test(definition, success=True, now=None):
     definition = Definition.from_data(definition)
     zettarepl = create_zettarepl(definition)
-    zettarepl._spawn_replication_tasks(select_by_class(ReplicationTask, definition.tasks))
+    zettarepl._spawn_replication_tasks(now, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 
     if success:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 81db3cd47c66982b4592e005aeb1e8f678fb5725

@rick-mesta this seems to be too much of a change for 13.0, should we move this to 22.02?

Original PR: https://github.com/truenas/zettarepl/pull/206
Jira URL: https://jira.ixsystems.com/browse/NAS-111800