### PR TITLE
NAS-114533 / 22.02 / Explicitly run `sh` on the remote machine because user login shell mi… (by themylogin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Color logging is automatically disabled when stderr is not a tty.
 Prerequisites:
 * FreeBSD or Linux VM with recent Python 3 installation. TrueNAS preferred (there are some TrueNAS-specific tests that
   will otherwise fail) but not required.
+* `sysctl vfs.usermount=1` for FreeBSD
 * root SSH key that will allow passwordless `ssh root@localhost`
 * `user` user with the same SSH key
 * `data` ZFS pool mounted in `/mnt/data`

--- a/zettarepl/transport/ssh.py
+++ b/zettarepl/transport/ssh.py
@@ -129,9 +129,9 @@ class SshReplicationProcess(ReplicationProcess, ProgressReportMixin):
                 send = pipe(send, ["throttle", "-B", str(self.speed_limit)])
 
             if self.direction == ReplicationDirection.PUSH:
-                commands = [send, cmd + [f"{PATH} " + implode(recv)]]
+                commands = [send, cmd + [implode(["sh", "-c", f"{PATH} " + implode(recv)])]]
             elif self.direction == ReplicationDirection.PULL:
-                commands = [cmd + [f"{PATH} " + implode(send)], recv]
+                commands = [cmd + [implode(["sh", "-c", f"{PATH} " + implode(send)])], recv]
             else:
                 raise ValueError(f"Invalid replication direction: {self.direction!r}")
 

--- a/zettarepl/transport/zfscli/exception.py
+++ b/zettarepl/transport/zfscli/exception.py
@@ -180,6 +180,6 @@ class ZfsSendRecvExceptionHandler:
             re.search(r"cannot mount '.+': Insufficient privileges", exc_val.stdout)
         ):
             raise ReplicationError(
-                f"{exc_val.stdout.rstrip('.')}. Please make sure replication user has write permissions to its "
-                f"parent dataset"
+                exc_val.stdout.rstrip("\n").rstrip(".") + ". Please make sure that replication user has write "
+                "permissions to its parent dataset"
             ) from None


### PR DESCRIPTION
…ght not be sh-compatible

Original PR: https://github.com/truenas/zettarepl/pull/214
Jira URL: https://jira.ixsystems.com/browse/NAS-114533