### PR TITLE
Fix schema for replication-task lifetimes

### DIFF
--- a/zettarepl/definition/schema/replication-task.schema.yaml
+++ b/zettarepl/definition/schema/replication-task.schema.yaml
@@ -118,10 +118,11 @@ properties:
         - schedule
         - lifetime
         additionalProperties: false
-        schedule:
-          $ref: http://freenas.org/zettarepl/schedule.schema.json
-        lifetime:
-          type: string
+        properties:
+          schedule:
+            $ref: http://freenas.org/zettarepl/schedule.schema.json
+          lifetime:
+            type: string
   compression:
     type: string
     enum:


### PR DESCRIPTION
It seems that previously the schema was malformed, and validation fails to expect either `schedule` or `lifetimes` in a lifetime definition.

These changes are untested but, going by my understanding of how these schemas are supposed to work, this part of the definition stands apart by having its properties defined at the same top level as `additionalProperties` and `required` rather than nested under some kind of `properties` key.