### PR TITLE
NAS-125338 / 13.0 / Close stdin/stdout/stderr (by amelchio) (by bugclerk) (by bugclerk)

### DIFF
--- a/zettarepl/transport/base_ssh.py
+++ b/zettarepl/transport/base_ssh.py
@@ -46,24 +46,27 @@ class SshTransportAsyncExec(AsyncExec):
             assert timeout > 0
             until = time.monotonic() + timeout
 
-        stdout = self._read_stdout(until)
+        try:
+            stdout = self._read_stdout(until)
 
-        self.logger.debug("Waiting for exit status")
+            self.logger.debug("Waiting for exit status")
 
-        if until is not None:
-            now = time.monotonic()
-            if until < now or not self.stdout_fd.channel.status_event.wait(until - now):
-                self._stop()
-                raise TimeoutError()
+            if until is not None:
+                now = time.monotonic()
+                if until < now or not self.stdout_fd.channel.status_event.wait(until - now):
+                    self._stop()
+                    raise TimeoutError()
 
-        exitcode = self.stdout_fd.channel.recv_exit_status()
+            exitcode = self.stdout_fd.channel.recv_exit_status()
 
-        if exitcode != 0:
-            self.logger.debug("Error %r: %r", exitcode, stdout)
-            raise ExecException(exitcode, stdout)
+            if exitcode != 0:
+                self.logger.debug("Error %r: %r", exitcode, stdout)
+                raise ExecException(exitcode, stdout)
 
-        self.logger.debug("Success: %r", stdout)
-        return stdout
+            self.logger.debug("Success: %r", stdout)
+            return stdout
+        finally:
+            self._stop()
 
     def _read_stdout(self, until):
         if self.stdout is None:
@@ -97,7 +100,12 @@ class SshTransportAsyncExec(AsyncExec):
         self._stop()
 
     def _stop(self):
-        self.stdout_fd.close()
+        if self.stdin_fd:
+            self.stdin_fd.close()
+            self.stdout_fd.close()
+            self.stderr_fd.close()
+
+            self.stdin_fd, self.stdout_fd, self.stderr_fd = (None, None, None)
 
     def _stdout_file_like_readline(self, file_like):
         while True:


### PR DESCRIPTION
This PR fixes a fatal memory leak in our TrueNAS CORE setup. I am not 100% sure why it works so let me tell you how I arrived at this.

The TrueNAS server ran out of its 128GB of memory on a monthly basis, fixable only by a reboot. I finally checked it mid-month and noticed a huge `zettarepl` process.

Digging in, zettarepl would start leaking memory some hours after a restart – but not due to any particular job (so there probably is a kind of race involved).

I noticed that whenever the leaking started, `zettarepl` would grow from five to seven permanent threads. The two extra threads were named like `Thread-17428` and `retention.close_shell`.

Hmm, what the heck is a "close shell" thread ... well, it turns out that it was introduced in #166 to fix a replication hang reported in https://ixsystems.atlassian.net/browse/NAS-110234. It seems like the hang was concealed more than actually fixed and leaving the thread around somehow causes the memory leak ("somehow" => this is the part where I am not 100% sure why).

Anyway, I searched for issues with Paramiko hanging on close and ended up at https://github.com/paramiko/paramiko/issues/2075#issuecomment-1178468092 which states:

> `stdin`, `stdout` and `stderr` objects from `SSHClient.exec_command()` should be closed before closing an instance of `SSHClient` if you invoked `SSHClient.exec_command()`.

Looking for `std*.close()` in zettarepl I didn't find much and what I did find was rarely called.

So on a hunch, I added explicit closing of all the fds and hooray, no more leaks.

(I think #166 can be reverted after this change but I have no way to verify the original report. So to keep the PR in "it can't hurt" territorry, I didn't include that cleanup.)



Original PR: https://github.com/truenas/zettarepl/pull/288
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125338

Original PR: https://github.com/truenas/zettarepl/pull/289
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125338

Original PR: https://github.com/truenas/zettarepl/pull/290
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125338