### PR TITLE
NAS-125693 / 23.10.2 / Fix periodic snapshot task snapshot lifetime (by themylogin)

### DIFF
--- a/zettarepl/snapshot/task/snapshot_owner.py
+++ b/zettarepl/snapshot/task/snapshot_owner.py
@@ -34,7 +34,7 @@ class PeriodicSnapshotTaskSnapshotOwner(SnapshotOwner):
 
     def should_retain(self, dataset: str, parsed_snapshot_name: ParsedSnapshotName):
         delete_before = self.idealized_now - self.periodic_snapshot_task.lifetime
-        return idealized_datetime(parsed_snapshot_name.datetime) >= delete_before
+        return idealized_datetime(parsed_snapshot_name.datetime) > delete_before
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.periodic_snapshot_task.id!r}>"


### PR DESCRIPTION
It it is `06:00` and snaspshot lifetime is `1 hour` then we should remove all snapshots that were created at 05:00 or earlier (or retain all that were `created at > 05:00`). So, the snapshot created at 05:00 should be removed at 06:00.

Previously we were retaining all snapshots that were `created at >= 05:00` (thus, removing all that were `created at < 05:00`). So the snapshot created at 05:00 was not removed at 06:00.

Original PR: https://github.com/truenas/zettarepl/pull/292
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125693