### PR TITLE
NAS-125861 / 23.10.2 / add Terabyte to zfs send progress parsing regex (by rene-dev)

### DIFF
--- a/zettarepl/transport/progress_report_mixin.py
+++ b/zettarepl/transport/progress_report_mixin.py
@@ -34,6 +34,9 @@ def parse_zfs_progress_value(s):
     elif s.endswith("G"):
         multiplier = 1000000000
         s = s[:-1]
+    elif s.endswith("T"):
+        multiplier = 1000000000000
+        s = s[:-1]
 
     return int(float(s) * multiplier)
 

--- a/zettarepl/transport/progress_report_mixin.py
+++ b/zettarepl/transport/progress_report_mixin.py
@@ -14,7 +14,7 @@ __all__ = ["ProgressReportMixin"]
 
 def parse_zfs_progress(s):
     m = re.search(
-        r"zfs: sending (?P<snapshot>.+) \([0-9]+%: (?P<current>[0-9.]+[KMG]?)/(?P<total>[0-9.]+[KMG]?)\)",
+        r"zfs: sending (?P<snapshot>.+) \([0-9]+%: (?P<current>[0-9.]+[KMGT]?)/(?P<total>[0-9.]+[KMGT]?)\)",
         s,
     )
     if m:


### PR DESCRIPTION
This fixes a replication tast appearing to be stuck with no progress, as the regex cant parse Terabyte.
`[2023/12/22 13:25:37] DEBUG    [replication_task__task_1.progress_observer] [zettarepl.transport.progress_report_mixin] Unable to find ZFS send progress in 'COMMAND\nzfs: sending pool1/tex@auto-20231221.0400-6m (48%: 922G/1.87T) (zfs)\n'`

Original PR: https://github.com/truenas/zettarepl/pull/296
Jira URL: https://ixsystems.atlassian.net/browse/NAS-125861