### PR TITLE
NAS-140699 / 26.0.0-BETA.2 / Backport bugfixes and tests for bugs found during mypy work

### DIFF
--- a/integration-tests/replication/test_pre_retention.py
+++ b/integration-tests/replication/test_pre_retention.py
@@ -1,5 +1,6 @@
 # -*- coding=utf-8 -*-
 from datetime import datetime
+import logging
 import subprocess
 import textwrap
 
@@ -115,3 +116,50 @@ def test_pre_retention_multiple_source_datasets():
 
     local_shell = LocalShell()
     assert len(list_snapshots(local_shell, "tank/dst/Family_Media", False)) == 3
+
+
+def test_pre_retention_keeps_incremental_base(caplog):
+    subprocess.call("zfs destroy -r tank/src", shell=True)
+    subprocess.call("zfs destroy -r tank/dst", shell=True)
+
+    create_dataset("tank/src")
+    subprocess.check_call("zfs snapshot -r tank/src@2018-10-01_01-00", shell=True)
+    subprocess.check_call("zfs snapshot -r tank/src@2018-10-02_01-00", shell=True)
+    subprocess.check_call("zfs snapshot -r tank/src@2018-10-03_01-00", shell=True)
+    subprocess.check_call("zfs send -R tank/src@2018-10-03_01-00 | zfs recv -s -F tank/dst", shell=True)
+    subprocess.check_call("zfs snapshot -r tank/src@2020-10-01_01-00", shell=True)
+
+    definition = yaml.safe_load(textwrap.dedent(f"""\
+        timezone: "UTC"
+
+        replication-tasks:
+          src:
+            direction: push
+            transport:
+              type: local
+            source-dataset: tank/src
+            target-dataset: tank/dst
+            also-include-naming-schema: "%Y-%m-%d_%H-%M"
+            recursive: false
+            auto: false
+            retention-policy: custom
+            lifetime: P1Y
+            retries: 1
+    """))
+
+    caplog.set_level(logging.DEBUG)
+    run_replication_test(definition, now=datetime(2020, 10, 1))
+
+    assert any(
+        record.message == (
+            "Not destroying '2018-10-03_01-00' as it is the only snapshot left for naming schema '%Y-%m-%d_%H-%M'"
+        )
+        for record in caplog.get_records("call")
+    )
+    assert any(
+        record.message == (
+            "Pre-retention destroying snapshots: [Snapshot(dataset='tank/dst', name='2018-10-01_01-00'), "
+            "Snapshot(dataset='tank/dst', name='2018-10-02_01-00')]"
+        )
+        for record in caplog.get_records("call")
+    )

--- a/integration-tests/replication/test_snapshots_to_send.py
+++ b/integration-tests/replication/test_snapshots_to_send.py
@@ -1,0 +1,52 @@
+# -*- coding=utf-8 -*-
+import subprocess
+import textwrap
+from unittest.mock import Mock
+
+import pytest
+import yaml
+
+from zettarepl.observer import ReplicationTaskSnapshotSuccess
+from zettarepl.utils.test import run_replication_test
+
+
+def test_only_from_scratch():
+    subprocess.call("zfs destroy -r tank/src", shell=True)
+    subprocess.call("zfs receive -A tank/dst", shell=True)
+    subprocess.call("zfs destroy -r tank/dst", shell=True)
+
+    subprocess.check_call("zfs create tank/src", shell=True)
+    subprocess.check_call("zfs snapshot tank/src@2018-10-01_01-00", shell=True)
+    subprocess.check_call("zfs snapshot tank/src@2100-10-01_01-00", shell=True)
+
+    definition = yaml.safe_load(textwrap.dedent(f"""\
+        timezone: "Europe/Moscow"
+
+        replication-tasks:
+          src:
+            direction: push
+            transport:
+              type: local
+            source-dataset: tank/src
+            target-dataset: tank/dst
+            recursive: true
+            also-include-naming-schema:
+              - "%Y-%m-%d_%H-%M"
+            auto: false
+            only-from-scratch: true
+            retention-policy: custom
+            lifetime: P7D
+            retries: 1
+    """))
+    observer = Mock(return_value=None)
+    run_replication_test(definition, observer=observer)
+    """
+    [call(<zettarepl.observer.ReplicationTaskStart object at 0x7fda183cd940>),
+     call(<zettarepl.observer.ReplicationTaskSnapshotStart object at 0x7fda183ce3c0>),
+     call(<zettarepl.observer.ReplicationTaskSnapshotSuccess object at 0x7fda183ceba0>),
+     call(<zettarepl.observer.ReplicationTaskSuccess object at 0x7fda183ce7b0>)]
+    So it sends only one snapshot, not two
+    """
+    assert len(observer.call_args_list) == 4
+    assert isinstance(observer.call_args_list[2][0][0], ReplicationTaskSnapshotSuccess)
+    assert observer.call_args_list[2][0][0].snapshot == "2100-10-01_01-00"

--- a/integration-tests/snapshot/test_legit_step_back.py
+++ b/integration-tests/snapshot/test_legit_step_back.py
@@ -45,7 +45,7 @@ def test_snapshot_exclude():
         None,
     ]
     tz_clock = TzClock(definition.timezone, datetime(2010, 10, 30, 21, 59, 59))
-    zettarepl = create_zettarepl(definition, Scheduler(clock, tz_clock))
+    zettarepl = create_zettarepl(definition, scheduler=Scheduler(clock, tz_clock))
     zettarepl.run()
 
     assert isinstance(zettarepl.observer.call_args_list[0][0][0], PeriodicSnapshotTaskStart)

--- a/zettarepl/replication/pre_retention.py
+++ b/zettarepl/replication/pre_retention.py
@@ -22,17 +22,6 @@ class RetentionBeforePushReplicationSnapshotOwner(ExecutedReplicationTaskSnapsho
         self.target_dataset = target_dataset
         super().__init__(*args, **kwargs)
 
-        for dst_dataset, snapshots in self.delete_snapshots.items():
-            incremental_base = get_parsed_incremental_base(
-                self.parsed_src_snapshots_names.get(get_source_dataset(self.replication_task, dst_dataset), []),
-                self.parsed_dst_snapshots_names[dst_dataset]
-            )
-            if incremental_base:
-                try:
-                    snapshots.remove(incremental_base)
-                except ValueError:
-                    pass
-
     def owns_dataset(self, dataset: str):
         # FIXME: Replication tasks that have multiple source datasets are executed as independent parts.
         # Retention has to be executed as independent parts too. Part 2 retention will not be executed until part 1

--- a/zettarepl/replication/snapshots_to_send.py
+++ b/zettarepl/replication/snapshots_to_send.py
@@ -102,6 +102,6 @@ def get_snapshots_to_send_with_naming_schemas(src_snapshots, dst_snapshots, repl
         snapshots_to_send, snapshots_to_send)
     snapshots_to_send = [parsed_snapshot.name
                          for parsed_snapshot in snapshots_to_send
-                         if parsed_snapshot not in will_be_removed]
+                         if parsed_snapshot.name not in will_be_removed]
 
     return SnapshotsToSend(incremental_base, snapshots_to_send, False, False)

--- a/zettarepl/utils/test.py
+++ b/zettarepl/utils/test.py
@@ -34,11 +34,11 @@ def create_dataset(name, encrypted=False):
         subprocess.check_call(f"zfs create {name}", shell=True)
 
 
-def create_zettarepl(definition, scheduler=None):
+def create_zettarepl(definition, scheduler=None, observer=None):
     local_shell = LocalShell()
     zettarepl = Zettarepl(scheduler or Mock(), local_shell, definition.max_parallel_replication_tasks)
     zettarepl._spawn_retention = Mock()
-    observer = Mock(return_value=None)
+    observer = observer or Mock(return_value=None)
     zettarepl.set_observer(observer)
     zettarepl.set_tasks(definition.tasks)
     return zettarepl
@@ -61,12 +61,12 @@ def run_periodic_snapshot_test(definition, now, success=True):
             assert not isinstance(call, PeriodicSnapshotTaskError), success
 
 
-def run_replication_test(definition, *, success=True, now=None):
+def run_replication_test(definition, *, success=True, now=None, observer=None):
     if now is None:
         now = Mock()
 
     definition = Definition.from_data(definition)
-    zettarepl = create_zettarepl(definition)
+    zettarepl = create_zettarepl(definition, observer=observer)
     zettarepl._spawn_replication_tasks(now, select_by_class(ReplicationTask, definition.tasks))
     wait_replication_tasks_to_complete(zettarepl)
 


### PR DESCRIPTION
mypy found a bug in `zettarepl/replication/snapshots_to_send.py`. Backporting the fix here.

Also, mypy found another bug in `zettarepl/replication/pre_retention.py`, but it didn't affect anything, since there's  general protection against deleting the newest remaining snapshot for any naming schema. Removed the dead code and also backported it here.