### PR TITLE
NAS-140875 / 27.0.0-BETA.1 / remove pytz dep

### DIFF
--- a/integration-tests/replication/test_dst.py
+++ b/integration-tests/replication/test_dst.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime, timezone
 from itertools import permutations
 import subprocess
 import textwrap
@@ -53,7 +53,7 @@ def test_dst(naming_schemas):
 
     run_periodic_snapshot_test(
         definition,
-        datetime(2010, 10, 30, 22, 0, 0, tzinfo=dt_timezone.utc).astimezone(ZoneInfo("Europe/Moscow"))
+        datetime(2010, 10, 30, 22, 0, 0, tzinfo=timezone.utc).astimezone(ZoneInfo("Europe/Moscow"))
     )
 
     local_shell = LocalShell()
@@ -64,7 +64,7 @@ def test_dst(naming_schemas):
 
     run_periodic_snapshot_test(
         definition,
-        datetime(2010, 10, 30, 23, 0, 0, tzinfo=dt_timezone.utc).astimezone(ZoneInfo("Europe/Moscow")),
+        datetime(2010, 10, 30, 23, 0, 0, tzinfo=timezone.utc).astimezone(ZoneInfo("Europe/Moscow")),
         None,
     )
 

--- a/integration-tests/replication/test_dst.py
+++ b/integration-tests/replication/test_dst.py
@@ -1,11 +1,11 @@
 # -*- coding=utf-8 -*-
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from itertools import permutations
 import subprocess
 import textwrap
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 import yaml
 
 from zettarepl.snapshot.list import list_snapshots
@@ -53,7 +53,7 @@ def test_dst(naming_schemas):
 
     run_periodic_snapshot_test(
         definition,
-        datetime(2010, 10, 30, 22, 0, 0, tzinfo=pytz.UTC).astimezone(pytz.timezone("Europe/Moscow"))
+        datetime(2010, 10, 30, 22, 0, 0, tzinfo=dt_timezone.utc).astimezone(ZoneInfo("Europe/Moscow"))
     )
 
     local_shell = LocalShell()
@@ -64,7 +64,7 @@ def test_dst(naming_schemas):
 
     run_periodic_snapshot_test(
         definition,
-        datetime(2010, 10, 30, 23, 0, 0, tzinfo=pytz.UTC).astimezone(pytz.timezone("Europe/Moscow")),
+        datetime(2010, 10, 30, 23, 0, 0, tzinfo=dt_timezone.utc).astimezone(ZoneInfo("Europe/Moscow")),
         None,
     )
 

--- a/integration-tests/retention/test_long_running_replication_task.py
+++ b/integration-tests/retention/test_long_running_replication_task.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-from datetime import datetime, timezone as dt_timezone
+from datetime import datetime, timezone
 import subprocess
 import textwrap
 import time
@@ -74,7 +74,7 @@ def test_long_running_replication_task_does_not_affect_unrelated_local_retention
     zettarepl.set_tasks(definition.tasks)
     zettarepl.scheduler.schedule.return_value = [
         Mock(datetime=Mock(datetime=datetime(2023, 5, 1, 0, 0),
-                           offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=dt_timezone.utc),
+                           offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=timezone.utc),
                            legit_step_back=None),
              tasks=[zettarepl.tasks[0]]),
     ]
@@ -184,7 +184,7 @@ def test_remote_retention_only_after_long_running_replication_task():
         zettarepl.set_tasks(definition.tasks)
         zettarepl.scheduler.schedule.return_value = [
             Mock(datetime=Mock(datetime=datetime(2023, 5, 1, 0, 0),
-                               offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=dt_timezone.utc),
+                               offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=timezone.utc),
                                legit_step_back=None),
                  tasks=[zettarepl.tasks[0]]),
         ]

--- a/integration-tests/retention/test_long_running_replication_task.py
+++ b/integration-tests/retention/test_long_running_replication_task.py
@@ -1,11 +1,10 @@
 # -*- coding=utf-8 -*-
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 import subprocess
 import textwrap
 import time
 from unittest.mock import Mock, patch
 
-import pytz
 import yaml
 
 from zettarepl.definition.definition import Definition
@@ -75,7 +74,7 @@ def test_long_running_replication_task_does_not_affect_unrelated_local_retention
     zettarepl.set_tasks(definition.tasks)
     zettarepl.scheduler.schedule.return_value = [
         Mock(datetime=Mock(datetime=datetime(2023, 5, 1, 0, 0),
-                           offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=pytz.utc),
+                           offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=dt_timezone.utc),
                            legit_step_back=None),
              tasks=[zettarepl.tasks[0]]),
     ]
@@ -185,7 +184,7 @@ def test_remote_retention_only_after_long_running_replication_task():
         zettarepl.set_tasks(definition.tasks)
         zettarepl.scheduler.schedule.return_value = [
             Mock(datetime=Mock(datetime=datetime(2023, 5, 1, 0, 0),
-                               offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=pytz.utc),
+                               offset_aware_datetime=datetime(2023, 5, 1, 0, 0, tzinfo=dt_timezone.utc),
                                legit_step_back=None),
                  tasks=[zettarepl.tasks[0]]),
         ]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ install_requires = [
     "jsonschema",
     "paramiko",
     "python-dateutil",
-    "pytz",
     "pyyaml",
 ]
 

--- a/tests/scheduler/test_tz_clock.py
+++ b/tests/scheduler/test_tz_clock.py
@@ -1,45 +1,51 @@
 # -*- coding=utf-8 -*-
-from datetime import datetime, timedelta
-
-from pytz import timezone
+from datetime import datetime, timedelta, timezone as dt_timezone
+from zoneinfo import ZoneInfo
 
 from zettarepl.scheduler.tz_clock import *
 
 
+def _local(utc: datetime, tz: ZoneInfo) -> datetime:
+    return utc.replace(tzinfo=dt_timezone.utc).astimezone(tz)
+
+
 def test__legit_time_backward():
-    tz = timezone("Europe/Moscow")
+    tz = ZoneInfo("Europe/Moscow")
 
     tz_clock = TzClock(tz, datetime(2010, 10, 30, 22, 59, 59))
 
+    expected_local = _local(datetime(2010, 10, 30, 23, 0, 0), tz)
     assert tz_clock.tick(datetime(2010, 10, 30, 23, 0, 0)) == TzClockDateTime(
-        tz.localize(datetime(2010, 10, 31, 2, 0, 0)).replace(tzinfo=None),
-        tz.localize(datetime(2010, 10, 31, 2, 0, 0)),
+        expected_local.replace(tzinfo=None),
+        expected_local,
         datetime(2010, 10, 30, 23, 0, 0),
         timedelta(hours=1),
     )
 
 
 def test__nonlegit_time_backward():
-    tz = timezone("Europe/Moscow")
+    tz = ZoneInfo("Europe/Moscow")
 
     tz_clock = TzClock(tz, datetime(2010, 8, 30, 22, 59, 59))
 
+    expected_local = _local(datetime(2010, 8, 30, 22, 59, 58), tz)
     assert tz_clock.tick(datetime(2010, 8, 30, 22, 59, 58)) == TzClockDateTime(
-        tz.localize(datetime(2010, 8, 31, 2, 59, 58)).replace(tzinfo=None),
-        tz.localize(datetime(2010, 8, 31, 2, 59, 58)),
+        expected_local.replace(tzinfo=None),
+        expected_local,
         datetime(2010, 8, 30, 22, 59, 58),
         None,
     )
 
 
 def test__time_forward():
-    tz = timezone("Europe/Moscow")
+    tz = ZoneInfo("Europe/Moscow")
 
     tz_clock = TzClock(tz, datetime(2010, 8, 30, 22, 59, 59))
 
+    expected_local = _local(datetime(2010, 8, 30, 23, 0, 0), tz)
     assert tz_clock.tick(datetime(2010, 8, 30, 23, 0, 0)) == TzClockDateTime(
-        tz.localize(datetime(2010, 8, 31, 3, 0, 0)).replace(tzinfo=None),
-        tz.localize(datetime(2010, 8, 31, 3, 0, 0)),
+        expected_local.replace(tzinfo=None),
+        expected_local,
         datetime(2010, 8, 30, 23, 0, 0),
         None,
     )

--- a/tests/scheduler/test_tz_clock.py
+++ b/tests/scheduler/test_tz_clock.py
@@ -1,12 +1,12 @@
 # -*- coding=utf-8 -*-
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from zettarepl.scheduler.tz_clock import *
 
 
 def _local(utc: datetime, tz: ZoneInfo) -> datetime:
-    return utc.replace(tzinfo=dt_timezone.utc).astimezone(tz)
+    return utc.replace(tzinfo=timezone.utc).astimezone(tz)
 
 
 def test__legit_time_backward():

--- a/zettarepl/definition/definition.py
+++ b/zettarepl/definition/definition.py
@@ -6,9 +6,9 @@ from datetime import tzinfo
 import logging
 from typing import Any, Sequence
 
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
 from dateutil.tz import tzlocal
-import pytz
-import pytz.exceptions
 
 from zettarepl.replication.task.task import ReplicationTask
 from zettarepl.snapshot.task.task import PeriodicSnapshotTask
@@ -85,8 +85,8 @@ class Definition:
         timezone: tzinfo = tzlocal()
         if "timezone" in data:
             try:
-                timezone = pytz.timezone(data["timezone"])
-            except pytz.exceptions.UnknownTimeZoneError:
+                timezone = ZoneInfo(data["timezone"])
+            except (ZoneInfoNotFoundError, ValueError):
                 errors.append(DefinitionError(f"Unknown timezone: {data['timezone']!r}"))
 
         periodic_snapshot_tasks = []

--- a/zettarepl/scheduler/tz_clock.py
+++ b/zettarepl/scheduler/tz_clock.py
@@ -1,6 +1,6 @@
 # -*- coding=utf-8 -*-
 from collections import namedtuple
-from datetime import datetime, timezone as dt_timezone, tzinfo
+from datetime import datetime, timezone, tzinfo
 import logging
 
 logger = logging.getLogger(__name__)
@@ -12,8 +12,8 @@ TzClockDateTime = namedtuple("TzClockDateTime", ["datetime", "offset_aware_datet
 
 
 class TzClock:
-    def __init__(self, timezone: tzinfo, utcnow: datetime) -> None:
-        self.timezone: tzinfo = timezone
+    def __init__(self, tz: tzinfo, utcnow: datetime) -> None:
+        self.timezone: tzinfo = tz
 
         self.utcnow: datetime = utcnow
         self.now: datetime = self._calculate_now(self.utcnow)
@@ -38,4 +38,4 @@ class TzClock:
             self.now_naive = now_naive
 
     def _calculate_now(self, utcnow: datetime) -> datetime:
-        return utcnow.replace(tzinfo=dt_timezone.utc).astimezone(self.timezone)
+        return utcnow.replace(tzinfo=timezone.utc).astimezone(self.timezone)

--- a/zettarepl/scheduler/tz_clock.py
+++ b/zettarepl/scheduler/tz_clock.py
@@ -1,9 +1,7 @@
 # -*- coding=utf-8 -*-
 from collections import namedtuple
-from datetime import datetime, tzinfo
+from datetime import datetime, timezone as dt_timezone, tzinfo
 import logging
-
-import pytz
 
 logger = logging.getLogger(__name__)
 
@@ -40,4 +38,4 @@ class TzClock:
             self.now_naive = now_naive
 
     def _calculate_now(self, utcnow: datetime) -> datetime:
-        return utcnow.replace(tzinfo=pytz.UTC).astimezone(self.timezone)
+        return utcnow.replace(tzinfo=dt_timezone.utc).astimezone(self.timezone)

--- a/zettarepl/snapshot/name.py
+++ b/zettarepl/snapshot/name.py
@@ -3,8 +3,7 @@ from datetime import datetime, tzinfo
 import logging
 import re
 from typing import Any, Iterable, NamedTuple
-
-import pytz
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 
@@ -138,8 +137,8 @@ def validate_snapshot_naming_schema(schema: str) -> None:
                          "ZFS snapshot names can't contain `+` so we use `--` instead.")
 
     for d in [
-        datetime(2000, 2, 29, 19, 40, tzinfo=pytz.timezone("Etc/GMT-10")),
-        datetime(2000, 2, 29, 19, 40, tzinfo=pytz.timezone("Etc/GMT+10")),
+        datetime(2000, 2, 29, 19, 40, tzinfo=ZoneInfo("Etc/GMT-10")),
+        datetime(2000, 2, 29, 19, 40, tzinfo=ZoneInfo("Etc/GMT+10")),
     ]:
         formatted = get_snapshot_name(d, schema)
         parsed = parse_snapshot_name(formatted, schema)


### PR DESCRIPTION
This is deprecated and has been replaced by built-in `zoneinfo` module. No reason to carry around extra baggage.