### PR TITLE
NAS-140908 / 27.0.0-BETA.1 / remove coloredlogs dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ exclude = [
 
 [[tool.mypy.overrides]]
 module = [
-    "coloredlogs.*", "isodate.*", "libzfs.*",
+    "isodate.*", "libzfs.*",
 ]
 ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "coloredlogs",
     "croniter",
     "isodate",
     "jsonschema",

--- a/zettarepl/main.py
+++ b/zettarepl/main.py
@@ -1,9 +1,6 @@
 # -*- coding=utf-8 -*-
 import argparse
 import logging
-import sys
-
-import coloredlogs
 
 from .commands.create_dataset import create_dataset
 from .commands.list_datasets import list_datasets
@@ -68,8 +65,6 @@ def main() -> None:
 
     logging_format = "[%(asctime)s] %(levelname)-8s [%(threadName)s] [%(name)s] %(message)s"
     logging.basicConfig(level=logging.DEBUG, format=logging_format)
-    if sys.stdout.isatty():
-        coloredlogs.install(level=logging.DEBUG, fmt=logging_format)
     for name, level in args.logging.loggers:
         logging.getLogger(name).setLevel(level)
     for handler in logging.getLogger().handlers:


### PR DESCRIPTION
No reason to carry a dependency just for this. This removes a transitive dependency (humanfriendly) as well.