### PR TITLE
NAS-140909 / 27.0.0-BETA.1 / remove isodate dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ exclude = [
 
 [[tool.mypy.overrides]]
 module = [
-    "isodate.*", "libzfs.*",
+    "libzfs.*",
 ]
 ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "croniter",
-    "isodate",
     "jsonschema",
     "paramiko",
     "python-dateutil",

--- a/zettarepl/replication/task/retention_policy.py
+++ b/zettarepl/replication/task/retention_policy.py
@@ -3,10 +3,9 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any, NamedTuple
 
-import isodate
-
 from zettarepl.scheduler.cron import CronSchedule
 from zettarepl.snapshot.name import ParsedSnapshotName
+from zettarepl.utils.datetime import parse_duration
 
 logger = logging.getLogger(__name__)
 
@@ -25,12 +24,12 @@ class TargetSnapshotRetentionPolicy:
                 raise ValueError("lifetime is required for custom retention policy")
 
             return CustomSnapshotRetentionPolicy(
-                isodate.parse_duration(data["lifetime"]),
+                parse_duration(data["lifetime"]),
                 sorted(
                     [
                         CustomSnapshotRetentionPolicyLifetime(
                             CronSchedule.from_data(lifetime["schedule"]),
-                            isodate.parse_duration(lifetime["lifetime"]),
+                            parse_duration(lifetime["lifetime"]),
                         )
                         for lifetime in data.get("lifetimes", {}).values()
                     ],

--- a/zettarepl/scheduler/cron.py
+++ b/zettarepl/scheduler/cron.py
@@ -3,7 +3,6 @@ from datetime import datetime, time, timedelta
 import logging
 from typing import Any, Self
 
-import isodate
 from croniter import croniter
 
 from zettarepl.definition.schema import schedule_validator
@@ -34,7 +33,7 @@ class CronSchedule:
         data.setdefault("end", "23:59")
 
         return cls(data["minute"], data["hour"], data["day-of-month"], data["month"], data["day-of-week"],
-                   isodate.parse_time(data["begin"]), isodate.parse_time(data["end"]))
+                   time.fromisoformat(data["begin"]), time.fromisoformat(data["end"]))
 
     def should_run(self, d: datetime) -> bool:
         idealized = idealized_datetime(d)

--- a/zettarepl/snapshot/task/task.py
+++ b/zettarepl/snapshot/task/task.py
@@ -3,12 +3,11 @@ from datetime import timedelta
 import logging
 from typing import Any, Self
 
-import isodate
-
 from zettarepl.definition.schema import periodic_snapshot_task_validator
 from zettarepl.scheduler.cron import CronSchedule
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 from zettarepl.task import Task
+from zettarepl.utils.datetime import parse_duration
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ class PeriodicSnapshotTask(Task):
         data.setdefault("allow-empty", True)
 
         if "lifetime" in data:
-            lifetime = isodate.parse_duration(data["lifetime"])
+            lifetime = parse_duration(data["lifetime"])
         else:
             # timedelta.max is not good here because operations with it would result in
             # OverflowError: date value out of range

--- a/zettarepl/utils/datetime.py
+++ b/zettarepl/utils/datetime.py
@@ -1,11 +1,31 @@
 # -*- coding=utf-8 -*-
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["idealized_datetime"]
+__all__ = ["idealized_datetime", "parse_duration"]
 
 
 def idealized_datetime(d: datetime) -> datetime:
     return d.replace(second=0, microsecond=0, tzinfo=None)
+
+
+_DURATION_RE = re.compile(
+    r"^P(?!$)"
+    r"(?:(?P<weeks>\d+(?:\.\d+)?)W)?"
+    r"(?:(?P<days>\d+(?:\.\d+)?)D)?"
+    r"(?:T(?=.)"
+    r"(?:(?P<hours>\d+(?:\.\d+)?)H)?"
+    r"(?:(?P<minutes>\d+(?:\.\d+)?)M)?"
+    r"(?:(?P<seconds>\d+(?:\.\d+)?)S)?"
+    r")?$"
+)
+
+
+def parse_duration(s: str) -> timedelta:
+    m = _DURATION_RE.fullmatch(s)
+    if m is None:
+        raise ValueError(f"Invalid ISO 8601 duration: {s!r}")
+    return timedelta(**{k: float(v) for k, v in m.groupdict().items() if v is not None})

--- a/zettarepl/utils/datetime.py
+++ b/zettarepl/utils/datetime.py
@@ -25,6 +25,12 @@ _DURATION_RE = re.compile(
 
 
 def parse_duration(s: str) -> timedelta:
+    """Parse an ISO 8601 duration into a timedelta.
+
+    Accepts weeks, days, hours, minutes, and seconds (e.g. P7W, P1DT12H30M).
+    Year and month components are not supported since they cannot be
+    represented as a fixed timedelta.
+    """
     m = _DURATION_RE.fullmatch(s)
     if m is None:
         raise ValueError(f"Invalid ISO 8601 duration: {s!r}")


### PR DESCRIPTION
Replaces the `isodate` third-party package with builtin Python functionality. The package was used in only three files for two functions, both easily covered by the standard library now that the project requires Python 3.11+.

- Added a small `parse_duration` helper in `zettarepl/utils/datetime.py`. It accepts ISO 8601 durations restricted to weeks, days, hours, minutes, and seconds, which is the full set of components representable as a `timedelta` and the only set ever used in this codebase.
- Replaced `isodate.parse_duration` calls in `zettarepl/snapshot/task/task.py` and `zettarepl/replication/task/retention_policy.py` with the new helper.
- Replaced `isodate.parse_time` calls in `zettarepl/scheduler/cron.py` with the stdlib `datetime.time.fromisoformat`, which handles every begin/end value the project uses.
- Dropped `isodate` from `setup.py` and removed the matching mypy override from `pyproject.toml`.

The primary caller is the TrueNAS middleware. In `middlewared/plugins/zettarepl.py`, `lifetime_iso8601` always emits durations of the form `PT<int>S`. Even MONTH and YEAR units are pre-flattened to days at the middleware layer (30 and 365 days respectively) before being formatted, so ISO year and month components never reach zettarepl. The `begin` and `end` schedule values are likewise emitted as plain `HH MM` strings.

The existing `lifetime` type annotation is `timedelta`, which means year and month durations were already implicitly unsupported. Sorting them in `CustomSnapshotRetentionPolicy` would have failed because `isodate.Duration` does not compare with `timedelta`. The new helper rejects those components explicitly rather than silently producing a value that breaks downstream code.

The hand-written YAML configs that appear in the integration tests use only `P1D`, `P14D`, `P30D`, `P7W`, and `PT1H`, all of which the new parser handles.

- All 145 unit tests pass.
- mypy `--strict` reports no issues on the four changed source files.