### PR TITLE
NAS-141175 / 27.0.0-BETA.1 / Fix integration tests

### DIFF
--- a/integration-tests/replication/test_pre_retention.py
+++ b/integration-tests/replication/test_pre_retention.py
@@ -143,7 +143,7 @@ def test_pre_retention_keeps_incremental_base(caplog):
             recursive: false
             auto: false
             retention-policy: custom
-            lifetime: P1Y
+            lifetime: P365D
             retries: 1
     """))
 


### PR DESCRIPTION
`isodate` replacement is incomplete and provokes lifetime parsing error