### PR TITLE
NAS-140878 / 27.0.0-BETA.1 / Extend error message for full ZFS replication when there are missing datasets

### DIFF
--- a/integration-tests/replication/test_replicate.py
+++ b/integration-tests/replication/test_replicate.py
@@ -138,3 +138,42 @@ def test_replicate(snapshot_to_destroy, error_text, snapshot_match_options, take
     error = run_replication_test(definition, success=error_text is None)
     if error_text is not None:
         assert error.error == error_text
+
+
+def test_replicate_dataset_rename():
+    subprocess.call("zfs destroy -r tank/src", shell=True)
+    subprocess.call("zfs receive -A tank/dst", shell=True)
+    subprocess.call("zfs destroy -r tank/dst", shell=True)
+
+    subprocess.check_call("zfs create tank/src", shell=True)
+    subprocess.check_call("zfs create tank/src/child1", shell=True)
+    subprocess.check_call("zfs create tank/src/child2", shell=True)
+    subprocess.check_call("zfs snapshot -r tank/src@2026-01-01_00-00", shell=True)
+    subprocess.check_call("zfs snapshot -r tank/src@2026-01-02_00-00", shell=True)
+    subprocess.check_call("zfs send -R tank/src@2026-01-02_00-00 | zfs recv tank/dst", shell=True)
+    subprocess.check_call("zfs rename tank/src/child2 tank/src/child3", shell=True)
+
+    definition = yaml.safe_load(textwrap.dedent("""\
+        timezone: "UTC"
+
+        replication-tasks:
+          src:
+            direction: push
+            transport:
+              type: local
+            source-dataset: tank/src
+            target-dataset: tank/dst
+            recursive: true
+            replicate: true
+            also-include-naming-schema:
+              - "%Y-%m-%d_%H-%M"
+            auto: false
+            retention-policy: source
+            retries: 1
+    """))
+    error = run_replication_test(definition, success=False)
+    assert " by running `zpool history tank | egrep 'rename.+tank/src/child3'`." in error.error
+
+    subprocess.call("zfs rename tank/dst/child2 tank/dst/child3", shell=True)
+
+    run_replication_test(definition)

--- a/zettarepl/replication/run.py
+++ b/zettarepl/replication/run.py
@@ -737,7 +737,11 @@ def check_base_consistency_for_full_replication(
             text += (
                 f"The snapshot {dst_dataset}@{snapshots_to_send.incremental_base} was not transferred. Please run "
                 f"`zfs destroy -r {step_template.dst_dataset}@{snapshots_to_send.incremental_base}` on the target "
-                "system and run replication again."
+                "system and run replication again. "
+                "Note that this error might also occur due to ZFS datasets being renamed on the source system. You can "
+                f"check this by running `zpool history {src_dataset.split('/')[0]} | egrep 'rename.+{src_dataset}'`."
+                f"If there are any relevant renames, repeat them on the destination system by running "
+                f"the corresponding `zfs rename` commands and try again."
             )
 
             raise ReplicationError(text)


### PR DESCRIPTION
Full ZFS replication fails when some of the source datasets with older snapshots are not present on the destination side.

This can happen in case of dataset rename. We do dataset renames when migrating from incus to new containers system, that's the root cause of the reported issue.

I am reluctant to try to replicate dataset renames automatically. We can try parsing `zpool history`, but, after all, it's just a text stream without any structure and there is no guarantee it is consistent with the real history.

Additionally, we can try matching renamed datasets by snapshots `guid`s (snapshots guid are the same on the source and destination system). However, this will require retrieving a lot of snapshot metadata on both source and destination systems, and add unnecessary complexity for such a rare case.