### PR TITLE
NAS-141175 / 26.0.0-RC.1 / Fix integration tests (by themylogin)

### DIFF
--- a/integration-tests/replication/test_pre_retention.py
+++ b/integration-tests/replication/test_pre_retention.py
@@ -143,7 +143,7 @@ def test_pre_retention_keeps_incremental_base(caplog):
             recursive: false
             auto: false
             retention-policy: custom
-            lifetime: P1Y
+            lifetime: P365D
             retries: 1
     """))
 


### PR DESCRIPTION
`isodate` replacement is incomplete and provokes lifetime parsing error

Original PR: https://github.com/truenas/zettarepl/pull/358
